### PR TITLE
yed file and cycle attribute

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Th_Update_7_1_15</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.python.pydev.PyDevBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.python.pydev.pythonNature</nature>
+	</natures>
+</projectDescription>

--- a/.pydevproject
+++ b/.pydevproject
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?eclipse-pydev version="1.0"?><pydev_project>
+<pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">Default</pydev_property>
+<pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python 2.7</pydev_property>
+</pydev_project>

--- a/Th_nodes.py
+++ b/Th_nodes.py
@@ -19,10 +19,10 @@ import networkx as nx
 import math
 
 # in progress function to identifie opposit nodes in cycle networks
-def oppositenodes(C,cnode1,cnode2):
+def oppositenodes(C,cnode1,cnode2,cycles):
     oppnodes=False;
-    cyc1=nx.get_node_attributes(C, "cycles")[cnode1]
-    cyc2=nx.get_node_attributes(C, "cycles")[cnode2]
+    cyc1=cycles[cnode1]
+    cyc2=cycles[cnode2]
     for n in cyc1:
         #if int(n) == float(n): ?
         for m in cyc2:
@@ -43,10 +43,10 @@ def inputCNodes(C,g):
 
 
 
-def opositeCnodes(C,cnode1, cnode2):
+def opositeCnodes(C,cnode1, cnode2,cycles):
     oppnodes=False;
-    cyc1=nx.get_node_attributes(C, "cycles")[cnode1]
-    cyc2=nx.get_node_attributes(C, "cycles")[cnode2]
+    cyc1=cycles[cnode1]
+    cyc2=cycles[cnode2]
     for n in cyc1:
         if(float(n)!=math.floor(float(n))):
             for m in cyc2:
@@ -120,6 +120,9 @@ for line in cycles.split('\n'):
 
 # creates undirected cycle network
 C=nx.Graph()
+#The export feature wasn't liking us putting the cycles as a node attribute, so I just created a separate dictionary for it
+#I also replaced all instances of "nx.get_node_attributes(C, 'cycles')" with "cycles", which should do the job
+cycles={}
 
 # declares a cycle node for each line in lines, delets the cycle node data from each line and then renames each line cycles 
 # bc that is the data they still contain
@@ -128,36 +131,37 @@ for line in lines:
     cycle=line
     cycle.remove(node)
     #ands a cycle node with the attribute of having its list of network nodes
-    C.add_node(node, cycles = line)
+    C.add_node(node)
+    cycles[node]=line
 
 dic={}
 #creates a dictionary for each expanded node in  each cycle node
 for c in C.nodes():
-    '''print c, nx.get_node_attributes(C, 'cycles')[c]'''
-    for expnode in nx.get_node_attributes(C, 'cycles')[c]:
+    '''print c, cycles[c]'''
+    for expnode in cycles[c]:
         if(float(expnode)!=int(float(expnode))):
             dic[expnode]=[]
 
 # assigns a cycle node for each expanded node
 for c in C.nodes():
-    '''print c, nx.get_node_attributes(C, 'cycles')[c]'''
-    for expnode in nx.get_node_attributes(C, 'cycles')[c]:
+    '''print c, cycles[c]'''
+    for expnode in cycles[c]:
         if(float(expnode)!=int(float(expnode))):
             current=dic[expnode]
             current.append(c)
             dic[expnode]=current
 
 #doing complicated stuff to print expanded node, it's inputs and then a list of cycles containg those inputs 
-'''
+
 for key in  dic.keys():
     cycnodes=dic[key]
     inputs=G.in_edges(key)
     print "INPUT",key,inputs
     for cnode1 in  range(len(cycnodes)):    
-        cyc1=nx.get_node_attributes(C, 'cycles')[cycnodes[cnode1]]    
+        cyc1=cycles[cycnodes[cnode1]]    
         for cnode2 in  range(len(cycnodes)):
             if(cnode2>cnode1):            
-                cyc2=nx.get_node_attributes(C, 'cycles')[cycnodes[cnode2]]   
+                cyc2=cycles[cycnodes[cnode2]]   
                 print "cyc1",cycnodes[cnode1],cyc1
                 print "cyc2",cycnodes[cnode2],cyc2            
                 inters1=[]
@@ -171,24 +175,24 @@ for key in  dic.keys():
                     trueboth=((true1 and true2) or (not true1 and not true2)) and trueboth
                 if(len(inters1)!=len(inters2)): C.add_edge(cycnodes[cnode1], cycnodes[cnode2]); print "NODE",cycnodes[cnode2],cycnodes[cnode1]             
                 elif(len(inters1)==len(inters2) and trueboth): C.add_edge(cycnodes[cnode1], cycnodes[cnode2]); print "NODE",cycnodes[cnode2],cycnodes[cnode1]
-'''
+
 #removing edges that connect cycles with opposite nodes            
 edgesremove=[]
 for e in C.edges():
     cnode1=e[0]
-    cnode1=e[1]
-    if oppositenodes(C,cnode1,cnode2):
+    cnode2=e[1]
+    if oppositenodes(C,cnode1,cnode2,cycles):
         edgesremove.append(e)
 C.remove_edges_from(edgesremove)
 
 #removing edges that connect cycles with opposite composit nodes
-edgesremove1=[]
-for e in C.edges():
-    cnode1=e[0]
-    cnode2=e[1]
-    if opositeCnodes(C,cnode1, cnode2):
-        edgesremove1.append(e)
-C.remove_edges_from(edgesremove1)
+# edgesremove1=[]
+# for e in C.edges():
+#     cnode1=e[0]
+#     cnode2=e[1]
+#     if opositeCnodes(C,cnode1, cnode2,cycles):
+#         edgesremove1.append(e)
+# C.remove_edges_from(edgesremove1)
 
 nx.write_gml(C, "th_cycleNetwork.gml")
     

--- a/th_cycleNetwork.gml
+++ b/th_cycleNetwork.gml
@@ -2,316 +2,1573 @@ graph [
   node [
     id 0
     label "56"
-    cycles ['10', '11', '5.5', '6']
   ]
   node [
     id 1
     label "54"
-    cycles ['3.5', '5']
   ]
   node [
     id 2
     label "42"
-    cycles ['-11', '17.5']
   ]
   node [
     id 3
     label "48"
-    cycles ['-14', '18.5']
   ]
   node [
     id 4
     label "43"
-    cycles ['-14', '11.5', '12', '19.5', '20', '8']
   ]
   node [
     id 5
     label "60"
-    cycles ['10', '17', '9']
   ]
   node [
     id 6
     label "61"
-    cycles ['11']
   ]
   node [
     id 7
     label "62"
-    cycles ['14']
   ]
   node [
     id 8
     label "49"
-    cycles ['-14', '19.5']
   ]
   node [
     id 9
     label "52"
-    cycles ['1.5', '12.5', '16', '22', '23', '3']
   ]
   node [
     id 10
     label "53"
-    cycles ['1.5', '13.5', '16', '22', '23', '3']
   ]
   node [
     id 11
     label "24"
-    cycles ['-12', '-20', '-4', '-8', '1.5', '10', '12.5', '16', '21', '22', '23', '3', '7']
   ]
   node [
     id 12
     label "25"
-    cycles ['-12', '-20', '-4', '-5', '-8', '1.5', '13.5', '16', '22', '23', '3']
   ]
   node [
     id 13
     label "26"
-    cycles ['-12', '-20', '-4', '-8', '1.5', '10', '13.5', '16', '21', '22', '23', '3', '7']
   ]
   node [
     id 14
     label "27"
-    cycles ['-12', '-20', '-5', '-8', '15.5']
   ]
   node [
     id 15
     label "20"
-    cycles ['-10', '-16', '-21', '-22', '-23', '-3', '-7', '11.5', '12', '14.5', '16.5', '2', '20', '23.5', '24.5', '4.5', '5', '8']
   ]
   node [
     id 16
     label "21"
-    cycles ['-10', '-16', '-21', '-22', '-23', '-3', '-7', '11.5', '12', '14.5', '16.5', '20', '23.5', '24.5', '4.5', '5', '8']
   ]
   node [
     id 17
     label "22"
-    cycles ['-10', '-11', '-16', '-21', '-22', '-23', '-3', '-7', '14', '14.5', '16.5', '17.5', '23.5', '7.5']
   ]
   node [
     id 18
     label "23"
-    cycles ['-12', '-20', '-4', '-5', '-8', '1.5', '12.5', '16', '22', '23', '3']
   ]
   node [
     id 19
     label "46"
-    cycles ['-14', '1.5', '10', '11', '13.5', '16', '18.5', '21', '22', '23', '3', '7']
   ]
   node [
     id 20
     label "47"
-    cycles ['-14', '1.5', '10', '13.5', '16', '18.5', '21', '22', '23', '3', '7']
   ]
   node [
     id 21
     label "44"
-    cycles ['-14', '1.5', '10', '11', '12.5', '16', '18.5', '21', '22', '23', '3', '7']
   ]
   node [
     id 22
     label "45"
-    cycles ['-14', '1.5', '10', '12.5', '16', '18.5', '21', '22', '23', '3', '7']
   ]
   node [
     id 23
     label "28"
-    cycles ['-5', '1.5', '3']
   ]
   node [
     id 24
     label "29"
-    cycles ['-12', '-20', '-5', '-8', '1.5', '10', '15.5', '21', '3', '7']
   ]
   node [
     id 25
     label "40"
-    cycles ['-12', '-20', '-8', '14', '7.5']
   ]
   node [
     id 26
     label "41"
-    cycles ['-10', '-17', '-9', '16.5']
   ]
   node [
     id 27
     label "1"
-    cycles ['-12', '-2', '-20', '-4', '-5', '-8', '1.5', '13.5', '16', '22', '23', '3']
   ]
   node [
     id 28
     label "0"
-    cycles ['-12', '-2', '-20', '-4', '-5', '-8', '1.5', '12.5', '16', '22', '23', '3']
   ]
   node [
     id 29
     label "3"
-    cycles ['-2', '-5', '1.5', '12.5', '16', '22', '23', '3']
   ]
   node [
     id 30
     label "2"
-    cycles ['-12', '-2', '-20', '-5', '-8', '15.5']
   ]
   node [
     id 31
     label "5"
-    cycles ['-16', '-22', '-23', '-3', '14.5']
   ]
   node [
     id 32
     label "4"
-    cycles ['-12', '-2', '-20', '-5', '-8', '1.5', '10', '12.5', '15.5', '16', '21', '22', '23', '3', '7']
   ]
   node [
     id 33
     label "7"
-    cycles ['-16', '-22', '-23', '-3', '11.5', '12', '14.5', '2', '20', '3.5', '4', '5', '8']
   ]
   node [
     id 34
     label "6"
-    cycles ['-3', '3.5', '5']
   ]
   node [
     id 35
     label "9"
-    cycles ['-16', '-22', '-23', '-3', '11.5', '12', '14.5', '20', '3.5', '4', '5', '8']
   ]
   node [
     id 36
     label "8"
-    cycles ['-16', '-22', '-23', '-3', '14.5', '2', '24.5', '3.5', '5']
   ]
   node [
     id 37
     label "51"
-    cycles ['2.5', '3']
   ]
   node [
     id 38
     label "39"
-    cycles ['-12', '-20', '-8', '14', '6.5']
   ]
   node [
     id 39
     label "38"
-    cycles ['-10', '-21', '-7', '16.5', '23.5']
   ]
   node [
     id 40
     label "59"
-    cycles ['10', '21', '7']
   ]
   node [
     id 41
     label "58"
-    cycles ['10', '5.5', '6']
   ]
   node [
     id 42
     label "11"
-    cycles ['-3', '4.5', '5']
   ]
   node [
     id 43
     label "10"
-    cycles ['-16', '-22', '-23', '-3', '14.5', '24.5', '3.5', '5']
   ]
   node [
     id 44
     label "13"
-    cycles ['-16', '-22', '-23', '-3', '14.5', '2', '24.5', '4.5', '5']
   ]
   node [
     id 45
     label "12"
-    cycles ['-16', '-22', '-23', '-3', '11.5', '12', '14.5', '2', '20', '4', '4.5', '5', '8']
   ]
   node [
     id 46
     label "15"
-    cycles ['-16', '-22', '-23', '-3', '14.5', '24.5', '4.5', '5']
   ]
   node [
     id 47
     label "14"
-    cycles ['-16', '-22', '-23', '-3', '11.5', '12', '14.5', '20', '4', '4.5', '5', '8']
   ]
   node [
     id 48
     label "17"
-    cycles ['-10', '-16', '-21', '-22', '-23', '-3', '-7', '14', '14.5', '16.5', '23.5', '6.5']
   ]
   node [
     id 49
     label "16"
-    cycles ['-3', '14.5']
   ]
   node [
     id 50
     label "19"
-    cycles ['-10', '-21', '-3', '-7', '11.5', '12', '16.5', '20', '23.5', '4.5', '5', '8']
   ]
   node [
     id 51
     label "18"
-    cycles ['-10', '-16', '-21', '-22', '-23', '-3', '-7', '11.5', '12', '14.5', '16.5', '20', '23.5', '4', '8']
   ]
   node [
     id 52
     label "31"
-    cycles ['-12', '-20', '-5', '-8', '10', '15.5', '2.5', '21', '3', '7']
   ]
   node [
     id 53
     label "30"
-    cycles ['-5', '2.5', '3']
   ]
   node [
     id 54
     label "37"
-    cycles ['-10', '-11', '-6', '16.5', '17.5']
   ]
   node [
     id 55
     label "36"
-    cycles ['-10', '-18', '-6', '16.5']
   ]
   node [
     id 56
     label "35"
-    cycles ['-10', '-6', '16.5']
   ]
   node [
     id 57
     label "34"
-    cycles ['-5', '15.5']
   ]
   node [
     id 58
     label "33"
-    cycles ['-12', '-20', '-5', '-8', '1.5', '10', '13.5', '15.5', '16', '21', '22', '23', '3', '7']
   ]
   node [
     id 59
     label "55"
-    cycles ['11.5', '12', '20', '4.5', '5', '8']
   ]
   node [
     id 60
     label "32"
-    cycles ['-5', '1.5', '13.5', '16', '22', '23', '3']
   ]
   node [
     id 61
     label "57"
-    cycles ['10', '18', '5.5', '6']
   ]
   node [
     id 62
     label "50"
-    cycles ['11.5', '12', '2', '20', '4.5', '5', '8']
+  ]
+  edge [
+    source 0
+    target 41
+  ]
+  edge [
+    source 1
+    target 35
+  ]
+  edge [
+    source 1
+    target 36
+  ]
+  edge [
+    source 1
+    target 43
+  ]
+  edge [
+    source 1
+    target 33
+  ]
+  edge [
+    source 1
+    target 34
+  ]
+  edge [
+    source 2
+    target 54
+  ]
+  edge [
+    source 2
+    target 17
+  ]
+  edge [
+    source 3
+    target 19
+  ]
+  edge [
+    source 3
+    target 20
+  ]
+  edge [
+    source 3
+    target 21
+  ]
+  edge [
+    source 3
+    target 22
+  ]
+  edge [
+    source 4
+    target 45
+  ]
+  edge [
+    source 4
+    target 15
+  ]
+  edge [
+    source 4
+    target 16
+  ]
+  edge [
+    source 4
+    target 8
+  ]
+  edge [
+    source 4
+    target 50
+  ]
+  edge [
+    source 4
+    target 62
+  ]
+  edge [
+    source 4
+    target 33
+  ]
+  edge [
+    source 9
+    target 11
+  ]
+  edge [
+    source 9
+    target 12
+  ]
+  edge [
+    source 9
+    target 13
+  ]
+  edge [
+    source 9
+    target 18
+  ]
+  edge [
+    source 9
+    target 19
+  ]
+  edge [
+    source 9
+    target 20
+  ]
+  edge [
+    source 9
+    target 21
+  ]
+  edge [
+    source 9
+    target 22
+  ]
+  edge [
+    source 9
+    target 10
+  ]
+  edge [
+    source 9
+    target 27
+  ]
+  edge [
+    source 9
+    target 28
+  ]
+  edge [
+    source 9
+    target 29
+  ]
+  edge [
+    source 9
+    target 32
+  ]
+  edge [
+    source 9
+    target 60
+  ]
+  edge [
+    source 9
+    target 58
+  ]
+  edge [
+    source 10
+    target 11
+  ]
+  edge [
+    source 10
+    target 12
+  ]
+  edge [
+    source 10
+    target 13
+  ]
+  edge [
+    source 10
+    target 18
+  ]
+  edge [
+    source 10
+    target 19
+  ]
+  edge [
+    source 10
+    target 20
+  ]
+  edge [
+    source 10
+    target 21
+  ]
+  edge [
+    source 10
+    target 22
+  ]
+  edge [
+    source 10
+    target 27
+  ]
+  edge [
+    source 10
+    target 28
+  ]
+  edge [
+    source 10
+    target 29
+  ]
+  edge [
+    source 10
+    target 32
+  ]
+  edge [
+    source 10
+    target 60
+  ]
+  edge [
+    source 10
+    target 58
+  ]
+  edge [
+    source 11
+    target 12
+  ]
+  edge [
+    source 11
+    target 13
+  ]
+  edge [
+    source 11
+    target 18
+  ]
+  edge [
+    source 11
+    target 19
+  ]
+  edge [
+    source 11
+    target 20
+  ]
+  edge [
+    source 11
+    target 21
+  ]
+  edge [
+    source 11
+    target 22
+  ]
+  edge [
+    source 11
+    target 27
+  ]
+  edge [
+    source 11
+    target 28
+  ]
+  edge [
+    source 11
+    target 29
+  ]
+  edge [
+    source 11
+    target 32
+  ]
+  edge [
+    source 11
+    target 60
+  ]
+  edge [
+    source 11
+    target 58
+  ]
+  edge [
+    source 12
+    target 13
+  ]
+  edge [
+    source 12
+    target 18
+  ]
+  edge [
+    source 12
+    target 19
+  ]
+  edge [
+    source 12
+    target 20
+  ]
+  edge [
+    source 12
+    target 21
+  ]
+  edge [
+    source 12
+    target 22
+  ]
+  edge [
+    source 12
+    target 23
+  ]
+  edge [
+    source 12
+    target 24
+  ]
+  edge [
+    source 12
+    target 27
+  ]
+  edge [
+    source 12
+    target 28
+  ]
+  edge [
+    source 12
+    target 29
+  ]
+  edge [
+    source 12
+    target 32
+  ]
+  edge [
+    source 12
+    target 60
+  ]
+  edge [
+    source 12
+    target 58
+  ]
+  edge [
+    source 13
+    target 18
+  ]
+  edge [
+    source 13
+    target 19
+  ]
+  edge [
+    source 13
+    target 20
+  ]
+  edge [
+    source 13
+    target 21
+  ]
+  edge [
+    source 13
+    target 22
+  ]
+  edge [
+    source 13
+    target 27
+  ]
+  edge [
+    source 13
+    target 28
+  ]
+  edge [
+    source 13
+    target 29
+  ]
+  edge [
+    source 13
+    target 32
+  ]
+  edge [
+    source 13
+    target 60
+  ]
+  edge [
+    source 13
+    target 58
+  ]
+  edge [
+    source 14
+    target 58
+  ]
+  edge [
+    source 14
+    target 52
+  ]
+  edge [
+    source 14
+    target 24
+  ]
+  edge [
+    source 14
+    target 57
+  ]
+  edge [
+    source 14
+    target 30
+  ]
+  edge [
+    source 14
+    target 32
+  ]
+  edge [
+    source 15
+    target 42
+  ]
+  edge [
+    source 15
+    target 43
+  ]
+  edge [
+    source 15
+    target 44
+  ]
+  edge [
+    source 15
+    target 45
+  ]
+  edge [
+    source 15
+    target 46
+  ]
+  edge [
+    source 15
+    target 16
+  ]
+  edge [
+    source 15
+    target 17
+  ]
+  edge [
+    source 15
+    target 49
+  ]
+  edge [
+    source 15
+    target 50
+  ]
+  edge [
+    source 15
+    target 51
+  ]
+  edge [
+    source 15
+    target 62
+  ]
+  edge [
+    source 15
+    target 59
+  ]
+  edge [
+    source 15
+    target 39
+  ]
+  edge [
+    source 15
+    target 31
+  ]
+  edge [
+    source 15
+    target 48
+  ]
+  edge [
+    source 15
+    target 33
+  ]
+  edge [
+    source 15
+    target 35
+  ]
+  edge [
+    source 15
+    target 36
+  ]
+  edge [
+    source 15
+    target 47
+  ]
+  edge [
+    source 16
+    target 42
+  ]
+  edge [
+    source 16
+    target 43
+  ]
+  edge [
+    source 16
+    target 44
+  ]
+  edge [
+    source 16
+    target 45
+  ]
+  edge [
+    source 16
+    target 47
+  ]
+  edge [
+    source 16
+    target 17
+  ]
+  edge [
+    source 16
+    target 49
+  ]
+  edge [
+    source 16
+    target 50
+  ]
+  edge [
+    source 16
+    target 51
+  ]
+  edge [
+    source 16
+    target 62
+  ]
+  edge [
+    source 16
+    target 46
+  ]
+  edge [
+    source 16
+    target 59
+  ]
+  edge [
+    source 16
+    target 39
+  ]
+  edge [
+    source 16
+    target 31
+  ]
+  edge [
+    source 16
+    target 48
+  ]
+  edge [
+    source 16
+    target 33
+  ]
+  edge [
+    source 16
+    target 35
+  ]
+  edge [
+    source 16
+    target 36
+  ]
+  edge [
+    source 17
+    target 43
+  ]
+  edge [
+    source 17
+    target 44
+  ]
+  edge [
+    source 17
+    target 45
+  ]
+  edge [
+    source 17
+    target 48
+  ]
+  edge [
+    source 17
+    target 49
+  ]
+  edge [
+    source 17
+    target 50
+  ]
+  edge [
+    source 17
+    target 51
+  ]
+  edge [
+    source 17
+    target 46
+  ]
+  edge [
+    source 17
+    target 39
+  ]
+  edge [
+    source 17
+    target 31
+  ]
+  edge [
+    source 17
+    target 54
+  ]
+  edge [
+    source 17
+    target 33
+  ]
+  edge [
+    source 17
+    target 35
+  ]
+  edge [
+    source 17
+    target 36
+  ]
+  edge [
+    source 17
+    target 47
+  ]
+  edge [
+    source 18
+    target 19
+  ]
+  edge [
+    source 18
+    target 20
+  ]
+  edge [
+    source 18
+    target 21
+  ]
+  edge [
+    source 18
+    target 22
+  ]
+  edge [
+    source 18
+    target 23
+  ]
+  edge [
+    source 18
+    target 24
+  ]
+  edge [
+    source 18
+    target 27
+  ]
+  edge [
+    source 18
+    target 28
+  ]
+  edge [
+    source 18
+    target 29
+  ]
+  edge [
+    source 18
+    target 32
+  ]
+  edge [
+    source 18
+    target 60
+  ]
+  edge [
+    source 18
+    target 58
+  ]
+  edge [
+    source 19
+    target 58
+  ]
+  edge [
+    source 19
+    target 20
+  ]
+  edge [
+    source 19
+    target 21
+  ]
+  edge [
+    source 19
+    target 22
+  ]
+  edge [
+    source 19
+    target 27
+  ]
+  edge [
+    source 19
+    target 28
+  ]
+  edge [
+    source 19
+    target 29
+  ]
+  edge [
+    source 19
+    target 32
+  ]
+  edge [
+    source 19
+    target 60
+  ]
+  edge [
+    source 20
+    target 60
+  ]
+  edge [
+    source 20
+    target 21
+  ]
+  edge [
+    source 20
+    target 22
+  ]
+  edge [
+    source 20
+    target 27
+  ]
+  edge [
+    source 20
+    target 28
+  ]
+  edge [
+    source 20
+    target 29
+  ]
+  edge [
+    source 20
+    target 32
+  ]
+  edge [
+    source 20
+    target 58
+  ]
+  edge [
+    source 21
+    target 22
+  ]
+  edge [
+    source 21
+    target 27
+  ]
+  edge [
+    source 21
+    target 28
+  ]
+  edge [
+    source 21
+    target 29
+  ]
+  edge [
+    source 21
+    target 32
+  ]
+  edge [
+    source 21
+    target 60
+  ]
+  edge [
+    source 21
+    target 58
+  ]
+  edge [
+    source 22
+    target 27
+  ]
+  edge [
+    source 22
+    target 28
+  ]
+  edge [
+    source 22
+    target 29
+  ]
+  edge [
+    source 22
+    target 32
+  ]
+  edge [
+    source 22
+    target 60
+  ]
+  edge [
+    source 22
+    target 58
+  ]
+  edge [
+    source 23
+    target 58
+  ]
+  edge [
+    source 23
+    target 60
+  ]
+  edge [
+    source 23
+    target 24
+  ]
+  edge [
+    source 23
+    target 27
+  ]
+  edge [
+    source 23
+    target 28
+  ]
+  edge [
+    source 23
+    target 29
+  ]
+  edge [
+    source 23
+    target 32
+  ]
+  edge [
+    source 24
+    target 58
+  ]
+  edge [
+    source 24
+    target 60
+  ]
+  edge [
+    source 24
+    target 52
+  ]
+  edge [
+    source 24
+    target 57
+  ]
+  edge [
+    source 24
+    target 27
+  ]
+  edge [
+    source 24
+    target 28
+  ]
+  edge [
+    source 24
+    target 29
+  ]
+  edge [
+    source 24
+    target 30
+  ]
+  edge [
+    source 24
+    target 32
+  ]
+  edge [
+    source 27
+    target 28
+  ]
+  edge [
+    source 27
+    target 29
+  ]
+  edge [
+    source 27
+    target 32
+  ]
+  edge [
+    source 27
+    target 60
+  ]
+  edge [
+    source 27
+    target 58
+  ]
+  edge [
+    source 28
+    target 58
+  ]
+  edge [
+    source 28
+    target 29
+  ]
+  edge [
+    source 28
+    target 32
+  ]
+  edge [
+    source 28
+    target 60
+  ]
+  edge [
+    source 29
+    target 32
+  ]
+  edge [
+    source 29
+    target 60
+  ]
+  edge [
+    source 29
+    target 58
+  ]
+  edge [
+    source 30
+    target 58
+  ]
+  edge [
+    source 30
+    target 52
+  ]
+  edge [
+    source 30
+    target 57
+  ]
+  edge [
+    source 30
+    target 32
+  ]
+  edge [
+    source 31
+    target 43
+  ]
+  edge [
+    source 31
+    target 44
+  ]
+  edge [
+    source 31
+    target 45
+  ]
+  edge [
+    source 31
+    target 49
+  ]
+  edge [
+    source 31
+    target 51
+  ]
+  edge [
+    source 31
+    target 46
+  ]
+  edge [
+    source 31
+    target 48
+  ]
+  edge [
+    source 31
+    target 33
+  ]
+  edge [
+    source 31
+    target 35
+  ]
+  edge [
+    source 31
+    target 36
+  ]
+  edge [
+    source 31
+    target 47
+  ]
+  edge [
+    source 32
+    target 60
+  ]
+  edge [
+    source 32
+    target 52
+  ]
+  edge [
+    source 32
+    target 57
+  ]
+  edge [
+    source 32
+    target 58
+  ]
+  edge [
+    source 33
+    target 43
+  ]
+  edge [
+    source 33
+    target 44
+  ]
+  edge [
+    source 33
+    target 45
+  ]
+  edge [
+    source 33
+    target 49
+  ]
+  edge [
+    source 33
+    target 59
+  ]
+  edge [
+    source 33
+    target 51
+  ]
+  edge [
+    source 33
+    target 34
+  ]
+  edge [
+    source 33
+    target 62
+  ]
+  edge [
+    source 33
+    target 46
+  ]
+  edge [
+    source 33
+    target 48
+  ]
+  edge [
+    source 33
+    target 35
+  ]
+  edge [
+    source 33
+    target 36
+  ]
+  edge [
+    source 33
+    target 47
+  ]
+  edge [
+    source 34
+    target 35
+  ]
+  edge [
+    source 34
+    target 43
+  ]
+  edge [
+    source 34
+    target 36
+  ]
+  edge [
+    source 35
+    target 43
+  ]
+  edge [
+    source 35
+    target 44
+  ]
+  edge [
+    source 35
+    target 45
+  ]
+  edge [
+    source 35
+    target 49
+  ]
+  edge [
+    source 35
+    target 50
+  ]
+  edge [
+    source 35
+    target 51
+  ]
+  edge [
+    source 35
+    target 62
+  ]
+  edge [
+    source 35
+    target 46
+  ]
+  edge [
+    source 35
+    target 59
+  ]
+  edge [
+    source 35
+    target 48
+  ]
+  edge [
+    source 35
+    target 36
+  ]
+  edge [
+    source 35
+    target 47
+  ]
+  edge [
+    source 36
+    target 43
+  ]
+  edge [
+    source 36
+    target 44
+  ]
+  edge [
+    source 36
+    target 45
+  ]
+  edge [
+    source 36
+    target 49
+  ]
+  edge [
+    source 36
+    target 51
+  ]
+  edge [
+    source 36
+    target 48
+  ]
+  edge [
+    source 36
+    target 46
+  ]
+  edge [
+    source 36
+    target 47
+  ]
+  edge [
+    source 37
+    target 52
+  ]
+  edge [
+    source 37
+    target 53
+  ]
+  edge [
+    source 39
+    target 48
+  ]
+  edge [
+    source 39
+    target 50
+  ]
+  edge [
+    source 39
+    target 51
+  ]
+  edge [
+    source 41
+    target 61
+  ]
+  edge [
+    source 42
+    target 44
+  ]
+  edge [
+    source 42
+    target 45
+  ]
+  edge [
+    source 42
+    target 46
+  ]
+  edge [
+    source 42
+    target 50
+  ]
+  edge [
+    source 42
+    target 47
+  ]
+  edge [
+    source 43
+    target 44
+  ]
+  edge [
+    source 43
+    target 45
+  ]
+  edge [
+    source 43
+    target 49
+  ]
+  edge [
+    source 43
+    target 51
+  ]
+  edge [
+    source 43
+    target 46
+  ]
+  edge [
+    source 43
+    target 48
+  ]
+  edge [
+    source 43
+    target 47
+  ]
+  edge [
+    source 44
+    target 45
+  ]
+  edge [
+    source 44
+    target 49
+  ]
+  edge [
+    source 44
+    target 50
+  ]
+  edge [
+    source 44
+    target 51
+  ]
+  edge [
+    source 44
+    target 46
+  ]
+  edge [
+    source 44
+    target 48
+  ]
+  edge [
+    source 44
+    target 47
+  ]
+  edge [
+    source 45
+    target 49
+  ]
+  edge [
+    source 45
+    target 50
+  ]
+  edge [
+    source 45
+    target 51
+  ]
+  edge [
+    source 45
+    target 62
+  ]
+  edge [
+    source 45
+    target 46
+  ]
+  edge [
+    source 45
+    target 59
+  ]
+  edge [
+    source 45
+    target 48
+  ]
+  edge [
+    source 45
+    target 47
+  ]
+  edge [
+    source 46
+    target 49
+  ]
+  edge [
+    source 46
+    target 50
+  ]
+  edge [
+    source 46
+    target 51
+  ]
+  edge [
+    source 46
+    target 48
+  ]
+  edge [
+    source 46
+    target 47
+  ]
+  edge [
+    source 47
+    target 49
+  ]
+  edge [
+    source 47
+    target 50
+  ]
+  edge [
+    source 47
+    target 51
+  ]
+  edge [
+    source 47
+    target 62
+  ]
+  edge [
+    source 47
+    target 59
+  ]
+  edge [
+    source 47
+    target 48
+  ]
+  edge [
+    source 48
+    target 49
+  ]
+  edge [
+    source 48
+    target 50
+  ]
+  edge [
+    source 48
+    target 51
+  ]
+  edge [
+    source 49
+    target 51
+  ]
+  edge [
+    source 50
+    target 59
+  ]
+  edge [
+    source 50
+    target 51
+  ]
+  edge [
+    source 50
+    target 62
+  ]
+  edge [
+    source 51
+    target 62
+  ]
+  edge [
+    source 52
+    target 58
+  ]
+  edge [
+    source 52
+    target 53
+  ]
+  edge [
+    source 52
+    target 57
+  ]
+  edge [
+    source 54
+    target 55
+  ]
+  edge [
+    source 54
+    target 56
+  ]
+  edge [
+    source 55
+    target 56
+  ]
+  edge [
+    source 57
+    target 58
+  ]
+  edge [
+    source 58
+    target 60
+  ]
+  edge [
+    source 59
+    target 62
   ]
 ]


### PR DESCRIPTION
The export feature wasn't liking us putting the cycles as a node attribute, so I just created a separate dictionary for it. I also replaced all instances of "nx.get_node_attributes(C, 'cycles')" with "cycles", which should do the job.
